### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean of type com.netflix.spectator.api.Registry available issue

### DIFF
--- a/igor-web/src/main/java/com/netflix/spinnaker/igor/config/IgorConfig.java
+++ b/igor-web/src/main/java/com/netflix/spinnaker/igor/config/IgorConfig.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.igor.config;
 
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig;
@@ -28,7 +27,6 @@ import com.netflix.spinnaker.kork.artifacts.parsing.DefaultJinjavaFactory;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjaArtifactExtractor;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjavaFactory;
 import com.netflix.spinnaker.kork.core.RetrySupport;
-import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener;
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor;
 import groovy.util.logging.Slf4j;
 import java.util.Collections;
@@ -52,23 +50,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableScheduling
 @Import(PluginsAutoConfiguration.class)
 public class IgorConfig implements WebMvcConfigurer {
-  @Bean
-  Registry getRegistry() {
-    return new DefaultRegistry();
-  }
 
-  @Bean
-  public DiscoveryStatusListener discoveryStatusListener() {
-    return new DiscoveryStatusListener();
-  }
+  private final Registry registry;
 
-  public IgorConfig() {}
+  public IgorConfig(Registry registry) {
+    this.registry = registry;
+  }
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(
         new MetricsInterceptor(
-            getRegistry(),
+            this.registry,
             "controller.invocations",
             Collections.singletonList("master"),
             null,


### PR DESCRIPTION

Fixed as suggested in:
spring-projects/spring-boot#33413

The 3.0 release notes link to the dedicated migration guide, which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70