### PR TITLE
fiat with authz enabled

### DIFF
--- a/igor-web/config/igor.yml
+++ b/igor-web/config/igor.yml
@@ -1,4 +1,4 @@
-services.fiat.baseUrl: https://fiat.net
+services.fiat.baseUrl: http://spin-fiat:7003
 
 netflix:
   appinfo:


### PR DESCRIPTION
OP-20457 fix for jenkins jobs not loading when authz is enabled

issue is IGOR not reading the override property `services.fiat.baseUrl:`  from spinnaker.yml. it is taking default property from gate.yml present on igor-web module