### PR TITLE
Junit4 to Junit5 Migration

### DIFF
--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountFactoryTest.java
@@ -20,11 +20,8 @@ import static org.mockito.Mockito.*;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.netflix.spinnaker.igor.config.GoogleCloudBuildProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildAccountFactoryTest {
   private final GoogleCredentialsService googleCredentialsService =
       mock(GoogleCredentialsService.class);

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildAccountRepositoryTest.java
@@ -18,15 +18,11 @@ package com.netflix.spinnaker.igor.gcb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildAccountRepositoryTest {
   @Test
   public void emptyRepository() {

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildExecutorTest.java
@@ -22,11 +22,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.services.cloudbuild.v1.CloudBuildRequest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GoogleCloudBuildExecutorTest {
   private GoogleCloudBuildExecutor executor = new GoogleCloudBuildExecutor();
 

--- a/igor-web/src/test/java/com/netflix/spinnaker/igor/MainTest.java
+++ b/igor-web/src/test/java/com/netflix/spinnaker/igor/MainTest.java
@@ -16,11 +16,10 @@
 
 package com.netflix.spinnaker.igor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-// @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {RedisConfig.class, Main.class})
 @TestPropertySource(properties = {"spring.application.name = igor"})
 public class MainTest {


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20760)
**Project Doc :** NA

Junit4 to Junit5 Migration

### How changes are verified
gradlew build & test - passing
see igor modules TCs detail : https://devopsmx.atlassian.net/browse/OP-20720

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA